### PR TITLE
Add fragment-based rule creation for unknown operations

### DIFF
--- a/app/css/base.css
+++ b/app/css/base.css
@@ -365,6 +365,12 @@ textarea:focus {
   justify-content: flex-end;
 }
 
+.filters .filters-note {
+  flex: 1 1 100%;
+  color: var(--fg-muted);
+  font-size: 14px;
+}
+
 .amount.neg {
   color: var(--danger);
 }

--- a/app/js/ui-unknown.js
+++ b/app/js/ui-unknown.js
@@ -3,6 +3,46 @@
     items: []
   };
 
+  function titleVariants(item) {
+    return [item.title || '', item.title_raw || '', item.title_normalized || ''];
+  }
+
+  function getFragmentValue() {
+    const fragmentInput = document.getElementById('unknown-fragment');
+    const searchInput = document.getElementById('unknown-search');
+    const fragment = fragmentInput ? fragmentInput.value.trim() : '';
+    if (fragment) {
+      return fragment;
+    }
+    return searchInput ? searchInput.value.trim() : '';
+  }
+
+  function computeFragmentMatches(fragment, type) {
+    if (!fragment) {
+      return { items: [], error: null };
+    }
+    if (type === 'regex') {
+      try {
+        const regex = new RegExp(fragment, 'i');
+        const items = state.items.filter(item => titleVariants(item).some(title => regex.test(title)));
+        return { items, error: null };
+      } catch (error) {
+        return { items: [], error };
+      }
+    }
+    const fragmentLower = fragment.toLowerCase();
+    const items = state.items.filter(item => {
+      return titleVariants(item).some(title => {
+        const normalized = title.toLowerCase();
+        if (type === 'exact') {
+          return normalized === fragmentLower;
+        }
+        return normalized.includes(fragmentLower);
+      });
+    });
+    return { items, error: null };
+  }
+
   function renderTable(filter = '') {
     const tbody = document.querySelector('#unknown-table tbody');
     const search = filter.toLowerCase();
@@ -27,6 +67,7 @@
       tr.innerHTML = '<td colspan="5">Все операции классифицированы! 🎉</td>';
       tbody.appendChild(tr);
     }
+    updatePreview();
   }
 
   function refreshState() {
@@ -38,12 +79,36 @@
     return Array.from(document.querySelectorAll('#unknown-table tbody input[data-select]:checked')).map(input => input.closest('tr').dataset.id);
   }
 
-  function createRuleFromSelection() {
-    const ids = selectedItems();
-    if (!ids.length) {
-      App.toast('Выберите операции для создания правила', { type: 'error' });
+  function updatePreview() {
+    const preview = document.getElementById('unknown-preview');
+    if (!preview) {
       return;
     }
+    const ids = selectedItems();
+    if (ids.length) {
+      preview.textContent = `Выбрано операций: ${ids.length}`;
+      return;
+    }
+    const type = document.getElementById('unknown-type').value;
+    const fragment = getFragmentValue();
+    if (!fragment) {
+      preview.textContent = 'Выберите операции или задайте фрагмент для правила';
+      return;
+    }
+    const { items, error } = computeFragmentMatches(fragment, type);
+    if (error) {
+      preview.textContent = 'Некорректный regex-паттерн';
+      return;
+    }
+    if (!items.length) {
+      preview.textContent = 'Подходящих операций не найдено';
+      return;
+    }
+    preview.textContent = `Будет классифицировано: ${items.length}`;
+  }
+
+  function createRuleFromSelection() {
+    const ids = selectedItems();
     const title = document.getElementById('unknown-normalize').value.trim();
     const category = document.getElementById('unknown-category').value.trim();
     const subcategory = document.getElementById('unknown-subcategory').value.trim();
@@ -53,9 +118,46 @@
       App.toast('Укажите нормализацию или выберите тип regex', { type: 'error' });
       return;
     }
-    const samples = state.items.filter(item => ids.includes(item.id));
-    const pattern = type === 'regex' ? document.getElementById('unknown-pattern').value.trim() : (title || samples[0].title_normalized || samples[0].title || '');
-    const match = type === 'regex' ? { type, pattern } : { type, value: pattern.toLowerCase() };
+    const fragment = getFragmentValue();
+    let samples = [];
+    let match;
+    if (ids.length) {
+      samples = state.items.filter(item => ids.includes(item.id));
+      if (!samples.length) {
+        App.toast('Не удалось найти выбранные операции', { type: 'error' });
+        return;
+      }
+      if (type === 'regex') {
+        if (!fragment) {
+          App.toast('Укажите regex-паттерн для правила', { type: 'error' });
+          return;
+        }
+        match = { type, pattern: fragment };
+      } else {
+        const basePattern = fragment || title || samples[0].title_normalized || samples[0].title || '';
+        if (!basePattern) {
+          App.toast('Не удалось определить фрагмент для правила', { type: 'error' });
+          return;
+        }
+        match = { type, value: basePattern.toLowerCase() };
+      }
+    } else {
+      if (!fragment) {
+        App.toast('Укажите фрагмент или используйте поиск для создания правила', { type: 'error' });
+        return;
+      }
+      const { items: matches, error } = computeFragmentMatches(fragment, type);
+      if (error) {
+        App.toast('Некорректный regex-паттерн', { type: 'error' });
+        return;
+      }
+      if (!matches.length) {
+        App.toast('Подходящих операций не найдено', { type: 'error' });
+        return;
+      }
+      samples = matches;
+      match = type === 'regex' ? { type, pattern: fragment } : { type, value: fragment.toLowerCase() };
+    }
     const newRule = {
       id: App.uid('rule'),
       priority,
@@ -66,10 +168,12 @@
       examples: samples.map(item => item.title || item.title_raw).slice(0, 5)
     };
     dictionaryAddRule(newRule);
-    const remaining = App.state.unknown.filter(item => !ids.includes(item.id));
+    const affectedIds = samples.map(item => item.id);
+    const remaining = App.state.unknown.filter(item => !affectedIds.includes(item.id));
     App.saveUnknown(remaining);
     reclassifyLedger();
     App.toast('Правило создано и применено', { type: 'success' });
+    updatePreview();
   }
 
   function dictionaryAddRule(rule) {
@@ -96,6 +200,14 @@
     document.getElementById('unknown-search').addEventListener('input', (event) => {
       renderTable(event.target.value);
     });
+    document.getElementById('unknown-fragment').addEventListener('input', updatePreview);
+    document.getElementById('unknown-type').addEventListener('change', updatePreview);
+    document.querySelector('#unknown-table tbody').addEventListener('change', (event) => {
+      if (event.target.matches('input[data-select]')) {
+        updatePreview();
+      }
+    });
     document.getElementById('unknown-create').addEventListener('click', createRuleFromSelection);
+    updatePreview();
   });
 })();

--- a/app/unknown.html
+++ b/app/unknown.html
@@ -26,17 +26,18 @@
       <div class="card-title">Создание правил из операций</div>
       <div class="filters">
         <input type="search" id="unknown-search" placeholder="Фильтр по описанию">
+        <input type="text" id="unknown-fragment" placeholder="Фрагмент для правила (опционально)">
         <select id="unknown-type">
           <option value="substring">substring</option>
           <option value="exact">exact</option>
           <option value="regex">regex</option>
         </select>
-        <input type="text" id="unknown-pattern" placeholder="Паттерн (для regex)">
         <input type="text" id="unknown-normalize" placeholder="Normalize to">
         <input type="text" id="unknown-category" placeholder="Категория">
         <input type="text" id="unknown-subcategory" placeholder="Подкатегория">
         <input type="number" id="unknown-priority" value="1200" step="10">
         <button class="btn" id="unknown-create">Создать правило</button>
+        <div class="filters-note" id="unknown-preview"></div>
       </div>
       <div class="table-wrapper">
         <table id="unknown-table">


### PR DESCRIPTION
## Summary
- add a fragment input and preview note to the unknown operations page
- extend rule creation logic to support fragment-based selection and live previews
- style the new preview helper in the filters layout

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cbb7745c008322ac2f6c194930585e