### PR TITLE
Enhance export schema with detailed fields

### DIFF
--- a/app/js/exporter.js
+++ b/app/js/exporter.js
@@ -1,16 +1,112 @@
 (function () {
-  const CSV_HEADERS = ['Дата', 'Описание', 'Категория', 'Подкатегория', 'Сумма', 'Источник', 'Комментарий'];
+  function makeField(header, getter) {
+    return { header, csv: getter, excel: getter };
+  }
+
+  function formatDateForExport(date) {
+    if (!date) return '';
+    const formatted = App.formatDate(date);
+    return formatted === '—' ? '' : formatted;
+  }
+
+  function parseAmount(value) {
+    if (value === null || value === undefined) return null;
+    if (typeof value === 'number') {
+      return Number.isFinite(value) ? value : null;
+    }
+    const normalized = String(value).replace(/\s+/g, '').replace(',', '.');
+    const parsed = parseFloat(normalized);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  function getAmountValue(op) {
+    if (!op || op.amount === undefined || op.amount === null) return null;
+    return parseAmount(op.amount);
+  }
+
+  function formatAmountForCsv(amount) {
+    if (amount === null) return '';
+    return amount.toFixed(2).replace('.', ',');
+  }
+
+  function formatAmountForExcel(amount) {
+    if (amount === null) return null;
+    return parseFloat(amount.toFixed(2));
+  }
+
+  function getSignValue(op, amount) {
+    if (op && op.sign !== undefined && op.sign !== null) {
+      const numericSign = Number(op.sign);
+      if (!Number.isNaN(numericSign)) {
+        if (numericSign > 0) return 1;
+        if (numericSign < 0) return -1;
+        return 0;
+      }
+    }
+    if (amount === null) return '';
+    if (amount > 0) return 1;
+    if (amount < 0) return -1;
+    return 0;
+  }
+
+  function sanitizeCsvValue(value) {
+    if (value === null || value === undefined) return '';
+    if (typeof value === 'number' && !Number.isFinite(value)) return '';
+    const str = String(value);
+    return str.replace(/"/g, '""');
+  }
+
+  function getSegment(op) {
+    return op.segment || op.project || '';
+  }
+
+  const EXPORT_FIELDS = [
+    makeField('Дата', op => formatDateForExport(op.date || op.bookingDate)),
+    makeField('Дата проводки', op => formatDateForExport(op.bookingDate)),
+    makeField('Описание', op => op.title || op.title_raw || ''),
+    makeField('Описание (raw)', op => op.title_raw || ''),
+    makeField('Категория', op => op.category || ''),
+    makeField('Подкатегория', op => op.subcategory || ''),
+    makeField('Сегмент', op => getSegment(op)),
+    makeField('Контрагент', op => op.counterparty || ''),
+    makeField('MCC', op => op.mcc || ''),
+    {
+      header: 'Сумма',
+      csv: op => {
+        const amount = getAmountValue(op);
+        return amount === null ? '' : formatAmountForCsv(amount);
+      },
+      excel: op => {
+        const amount = getAmountValue(op);
+        return formatAmountForExcel(amount);
+      }
+    },
+    {
+      header: 'Знак',
+      csv: op => getSignValue(op, getAmountValue(op)),
+      excel: op => getSignValue(op, getAmountValue(op))
+    },
+    makeField('Валюта', op => op.currency || 'RUB'),
+    makeField('Банк', op => op.bank || ''),
+    makeField('Источник', op => op.source_file || op.source_pdf || op.source || ''),
+    makeField('Внешний ID', op => op.externalId || op.external_id || ''),
+    makeField('Комментарий', op => op.comment || '')
+  ];
+
+  const CSV_HEADERS = EXPORT_FIELDS.map(field => field.header);
 
   function formatRow(op) {
-    const date = App.formatDate(op.date);
-    const title = (op.title || op.title_raw || '').replace(/"/g, '""');
-    const category = (op.category || '').replace(/"/g, '""');
-    const subcategory = (op.subcategory || '').replace(/"/g, '""');
-    const amount = (op.amount || 0).toString().replace('.', ',');
-    const source = op.source_file || op.bank || op.source_pdf || '';
-    const comment = (op.comment || '').replace(/"/g, '""');
-    return [date, title, category, subcategory, amount, source, comment]
-      .map(value => `"${value}"`).join(';');
+    return EXPORT_FIELDS
+      .map(field => `"${sanitizeCsvValue(field.csv(op))}"`)
+      .join(';');
+  }
+
+  function buildXlsxRow(op) {
+    return EXPORT_FIELDS.reduce((row, field) => {
+      const value = field.excel(op);
+      row[field.header] = value === undefined || value === null ? '' : value;
+      return row;
+    }, {});
   }
 
   function toCsv(operations) {
@@ -29,17 +125,11 @@
       throw new Error('SheetJS не загружен');
     }
     const wb = XLSX.utils.book_new();
-    const opSheet = XLSX.utils.json_to_sheet(operations.map(op => ({
-      'Дата': App.formatDate(op.date),
-      'Описание': op.title || op.title_raw,
-      'Категория': op.category || '',
-      'Подкатегория': op.subcategory || '',
-      'Сумма': op.amount,
-      'Валюта': op.currency || 'RUB',
-      'Банк': op.bank,
-      'Источник': op.source_file || '',
-      'Комментарий': op.comment || ''
-    })));
+    const opRows = operations.map(op => buildXlsxRow(op));
+    const opSheet = XLSX.utils.aoa_to_sheet([CSV_HEADERS]);
+    if (opRows.length) {
+      XLSX.utils.sheet_add_json(opSheet, opRows, { origin: 'A2', header: CSV_HEADERS, skipHeader: true });
+    }
     XLSX.utils.book_append_sheet(wb, opSheet, 'Операции');
     if (summary.length) {
       const summarySheet = XLSX.utils.json_to_sheet(summary);


### PR DESCRIPTION
## Summary
- expand the export headers to include booking date, raw text, segment, counterparty, MCC, sign, currency, bank, and external IDs alongside category data
- share the richer schema between CSV and XLSX exporters while normalizing amount formatting and derived signs

## Testing
- node - <<'NODE' ... (smoke test exporter)


------
https://chatgpt.com/codex/tasks/task_e_68cbb77e11f08322935f9132f939bfff